### PR TITLE
image_arn should not force new

### DIFF
--- a/appstream/resource_fleet.go
+++ b/appstream/resource_fleet.go
@@ -84,7 +84,6 @@ func resourceAppstreamFleet() *schema.Resource {
 			"image_arn": {
                 Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:	  true,
 			},
 
 			"iam_role_arn": {


### PR DESCRIPTION
Note that I did not test this change, but it should work. The AWS console allows you to change the image, as does the API.